### PR TITLE
fix-error-to-use-zoho-ui-modal-manipulation-functions

### DIFF
--- a/lib/ZohoCrmHelper.js
+++ b/lib/ZohoCrmHelper.js
@@ -331,7 +331,15 @@ var ZOHO = (function() {
                 var config = {
                     category: "UI"
                 };
-                $.extend(data, config);
+                
+                if("$" in window){
+                    // with new updates in zoho interface, JQuery might not be loaded
+                    // this part of the code will fail when calling Zoho UI modifier functions like close()
+                    $.extend(data, config);
+                }else{
+                    data = {...data, ...config}
+                    // this merges the objects data and config, like it would do using $.extend
+                }
                 return newRequestPromise(data);
             }
 


### PR DESCRIPTION
 With new updates in zoho interface, JQuery might not be loaded;

This part of the code will fail when calling Zoho UI modifier functions like close()

this merges the objects data and config, like it would do using $.extend